### PR TITLE
feat(claude): add ccstatusline status line

### DIFF
--- a/modules/features/ccstatusline.nix
+++ b/modules/features/ccstatusline.nix
@@ -1,0 +1,112 @@
+{config, ...}: {
+  flake.modules.homeManager.ccstatusline = {
+    self,
+    system,
+    pkgs,
+    lib,
+    config,
+    ...
+  }: let
+    cfg = config.programs.ccstatusline;
+    jsonFormat = pkgs.formats.json {};
+  in {
+    options.programs.ccstatusline = {
+      enable = lib.mkEnableOption "ccstatusline, a configurable status line for Claude Code";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = self.packages.${system}.ccstatusline;
+        defaultText = lib.literalExpression "self.packages.\${system}.ccstatusline";
+        description = "The ccstatusline package providing the {command}`ccstatusline` binary.";
+      };
+
+      settings = lib.mkOption {
+        inherit (jsonFormat) type;
+        default = {
+          version = 3;
+          lines = [
+            [
+              {
+                id = "1";
+                type = "model";
+                color = "cyan";
+              }
+              {
+                id = "2";
+                type = "separator";
+              }
+              {
+                id = "3";
+                type = "context-length";
+                color = "brightBlack";
+              }
+              {
+                id = "4";
+                type = "separator";
+              }
+              {
+                id = "5";
+                type = "git-branch";
+                color = "magenta";
+              }
+              {
+                id = "6";
+                type = "separator";
+              }
+              {
+                id = "7";
+                type = "git-changes";
+                color = "yellow";
+              }
+            ]
+            []
+            []
+          ];
+          flexMode = "full-minus-40";
+          compactThreshold = 60;
+          colorLevel = 2;
+          inheritSeparatorColors = false;
+          globalBold = false;
+          gitCacheTtlSeconds = 5;
+          minimalistMode = false;
+          powerline = {
+            enabled = false;
+            separators = [""];
+            separatorInvertBackground = [false];
+            startCaps = [];
+            endCaps = [];
+            autoAlign = false;
+            continueThemeAcrossLines = false;
+          };
+        };
+        description = ''
+          Configuration written verbatim to
+          {file}`$XDG_CONFIG_HOME/ccstatusline/settings.json`.
+
+          Each entry in `lines` is one status line (ccstatusline supports up to
+          three) and each widget is an object with a `type` such as `model`,
+          `separator`, `context-length`, `git-branch` or `git-changes`. Run
+          {command}`ccstatusline` to browse every available widget and preview
+          changes interactively.
+
+          Because this file is managed by Nix it is a read-only symlink into the
+          store, so the interactive editor cannot persist changes - edit this
+          option instead.
+
+          See <https://github.com/sirmalloc/ccstatusline>.
+        '';
+      };
+    };
+
+    config = lib.mkIf cfg.enable {
+      home.packages = [cfg.package];
+
+      xdg.configFile."ccstatusline/settings.json".source =
+        jsonFormat.generate "ccstatusline-settings.json" cfg.settings;
+    };
+  };
+
+  flake.modules.combined.ccstatusline = {...}: {
+    hm.imports = [config.flake.modules.homeManager.ccstatusline];
+  };
+}

--- a/modules/features/claude.nix
+++ b/modules/features/claude.nix
@@ -8,6 +8,7 @@
     ...
   }: let
     pkg = pkgs-unstable.claude-code;
+    ccstatusline = self.packages.${system}.ccstatusline;
     notifyScript = ''
       #!/usr/bin/env bash
       input=$(cat)
@@ -32,13 +33,14 @@
 
       settings = {
         # ccstatusline: a configurable status line for Claude Code.
-        # The status line is produced by running ccstatusline through bunx
-        # (bun is installed in home.packages below). ccstatusline keeps its own
-        # configuration in ~/.config/ccstatusline/settings.json, edited
-        # interactively with `bunx -y ccstatusline@latest`.
+        # Rendered by the pinned, Nix-built ccstatusline package (see
+        # pkgs/ccstatusline) rather than fetching it from npm at runtime, so the
+        # binary is fully declarative and reproducible. ccstatusline's own
+        # appearance config lives in ~/.config/ccstatusline/settings.json and is
+        # edited interactively with `ccstatusline`.
         statusLine = {
           type = "command";
-          command = "bunx -y ccstatusline@latest";
+          command = lib.getExe ccstatusline;
           padding = 0;
         };
 
@@ -323,6 +325,7 @@
       ]
       ++ [
         inputs.ccusage.outputs.packages.${system}.default
+        ccstatusline
         pkgs-unstable.bun
       ];
   };

--- a/modules/features/claude.nix
+++ b/modules/features/claude.nix
@@ -31,6 +31,28 @@
       package = pkg;
 
       settings = {
+        # ccstatusline: a configurable status line for Claude Code.
+        # The status line is produced by running ccstatusline through bunx
+        # (bun is installed in home.packages below). ccstatusline keeps its own
+        # configuration in ~/.config/ccstatusline/settings.json, edited
+        # interactively with `bunx -y ccstatusline@latest`.
+        statusLine = {
+          type = "command";
+          command = "bunx -y ccstatusline@latest";
+          padding = 0;
+        };
+
+        enabledPlugins = {
+          "gopls-lsp@claude-plugins-official" = true;
+          "lua-lsp@claude-plugins-official" = true;
+          "pr-review-toolkit@claude-plugins-official" = true;
+          "frontend-design@claude-plugins-official" = true;
+          "code-review@claude-plugins-official" = true;
+          "commit-commands@claude-plugins-official" = true;
+          "superpowers@superpowers-marketplace" = true;
+          "context-mode@context-mode" = true;
+        };
+
         permissions = {
           deny = [
             "Bash(sudo *)"
@@ -177,18 +199,6 @@
           repo = "context-mode";
           rev = "e17427240897ea8b07006382fecfac825d66e003";
           sha256 = "sha256-6FuI+4fTxcp3kp1WpJFMRUZnAGRRcTGJ1ZzOLgpMWVE=";
-        };
-      };
-      settings = {
-        enabledPlugins = {
-          "gopls-lsp@claude-plugins-official" = true;
-          "lua-lsp@claude-plugins-official" = true;
-          "pr-review-toolkit@claude-plugins-official" = true;
-          "frontend-design@claude-plugins-official" = true;
-          "code-review@claude-plugins-official" = true;
-          "commit-commands@claude-plugins-official" = true;
-          "superpowers@superpowers-marketplace" = true;
-          "context-mode@context-mode" = true;
         };
       };
     };

--- a/modules/features/claude.nix
+++ b/modules/features/claude.nix
@@ -29,7 +29,118 @@
 
     # ccstatusline package + declarative settings.json (programs.ccstatusline
     # module). Claude Code's statusLine below points at this package.
-    programs.ccstatusline.enable = true;
+    programs.ccstatusline = {
+      enable = true;
+      settings = {
+        version = 3;
+        lines = [
+          [
+            {
+              id = "1";
+              type = "model";
+              color = "cyan";
+            }
+            {
+              id = "2";
+              type = "separator";
+            }
+            {
+              id = "3";
+              type = "tokens-input";
+              color = "brightBlack";
+            }
+            {
+              id = "fe38dc05-fda2-4d3a-9fde-2021140e392d";
+              type = "separator";
+            }
+            {
+              id = "94349446-72cb-4aec-9fec-f371bdc34689";
+              type = "tokens-output";
+            }
+            {
+              id = "7892b992-08d7-4ef9-b613-66e12ae8b057";
+              type = "flex-separator";
+            }
+            {
+              id = "5";
+              type = "git-branch";
+              color = "magenta";
+            }
+            {
+              id = "6";
+              type = "separator";
+            }
+            {
+              id = "7";
+              type = "git-changes";
+              color = "yellow";
+            }
+            {
+              id = "0ecb9131-2c89-48e7-8738-0056522d39b6";
+              type = "separator";
+            }
+            {
+              id = "4f3f24ce-fc7c-4e52-a43c-feaae9664ad6";
+              type = "free-memory";
+            }
+          ]
+          [
+            {
+              id = "14210628-bbae-4fca-a09b-6f0f067813a6";
+              type = "session-clock";
+            }
+            {
+              id = "7850b984-405f-44ad-a7fc-1be46a5c5bfc";
+              type = "separator";
+            }
+            {
+              id = "3aa35e41-7c5f-4691-819b-5d6652b9eb35";
+              type = "session-cost";
+            }
+            {
+              id = "fb764e15-4ce0-416b-b67d-da943e7d606f";
+              type = "separator";
+            }
+            {
+              id = "7a881317-6ed7-4e6b-a5c2-a7b8fac91ce5";
+              type = "skills";
+            }
+            {
+              id = "2f486639-3611-4ba1-bcbe-d1de8868f7c5";
+              type = "flex-separator";
+            }
+            {
+              id = "5c862902-53f5-43ad-b3ff-afd5af4ddf8b";
+              type = "context-bar";
+            }
+          ]
+          [
+          ]
+        ];
+        flexMode = "full-minus-40";
+        compactThreshold = 60;
+        colorLevel = 2;
+        inheritSeparatorColors = false;
+        globalBold = false;
+        gitCacheTtlSeconds = 5;
+        minimalistMode = false;
+        powerline = {
+          enabled = false;
+          separators = [
+            ""
+          ];
+          separatorInvertBackground = [
+            false
+          ];
+          startCaps = [
+          ];
+          endCaps = [
+          ];
+          autoAlign = false;
+          continueThemeAcrossLines = false;
+        };
+      };
+    };
 
     programs.claude-code = {
       enable = true;

--- a/modules/features/claude.nix
+++ b/modules/features/claude.nix
@@ -5,10 +5,10 @@
     inputs,
     system,
     pkgs-unstable,
+    config,
     ...
   }: let
     pkg = pkgs-unstable.claude-code;
-    ccstatusline = self.packages.${system}.ccstatusline;
     notifyScript = ''
       #!/usr/bin/env bash
       input=$(cat)
@@ -27,20 +27,23 @@
       text = notifyScript;
     };
 
+    # ccstatusline package + declarative settings.json (programs.ccstatusline
+    # module). Claude Code's statusLine below points at this package.
+    programs.ccstatusline.enable = true;
+
     programs.claude-code = {
       enable = true;
       package = pkg;
 
       settings = {
-        # ccstatusline: a configurable status line for Claude Code.
-        # Rendered by the pinned, Nix-built ccstatusline package (see
-        # pkgs/ccstatusline) rather than fetching it from npm at runtime, so the
-        # binary is fully declarative and reproducible. ccstatusline's own
-        # appearance config lives in ~/.config/ccstatusline/settings.json and is
-        # edited interactively with `ccstatusline`.
+        # Status line is rendered by the pinned, Nix-built ccstatusline package
+        # (see pkgs/ccstatusline and the programs.ccstatusline module) rather
+        # than fetching it from npm at runtime, so it is fully declarative and
+        # reproducible. Its appearance is configured declaratively via
+        # programs.ccstatusline.settings.
         statusLine = {
           type = "command";
-          command = lib.getExe ccstatusline;
+          command = lib.getExe config.programs.ccstatusline.package;
           padding = 0;
         };
 
@@ -325,12 +328,14 @@
       ]
       ++ [
         inputs.ccusage.outputs.packages.${system}.default
-        ccstatusline
         pkgs-unstable.bun
       ];
   };
 
   flake.modules.combined.claude = {...}: {
-    hm.imports = [config.flake.modules.homeManager.claude];
+    hm.imports = [
+      config.flake.modules.homeManager.claude
+      config.flake.modules.homeManager.ccstatusline
+    ];
   };
 }

--- a/pkgs/ccstatusline/default.nix
+++ b/pkgs/ccstatusline/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  nodejs,
+}:
+# ccstatusline is a Bun-built CLI that ships a single, self-contained bundle
+# (dist/ccstatusline.js) with zero runtime dependencies, so we can package the
+# published npm tarball directly instead of building from source.
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ccstatusline";
+  version = "2.2.19";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/ccstatusline/-/ccstatusline-${finalAttrs.version}.tgz";
+    hash = "sha256-ZECyfJStzolhs1EQrrbq6svXCtvcpj6YJRPjFIazLSw=";
+  };
+
+  nativeBuildInputs = [makeBinaryWrapper];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/ccstatusline
+    cp -r dist package.json $out/lib/ccstatusline/
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/ccstatusline \
+      --inherit-argv0 \
+      --add-flags $out/lib/ccstatusline/dist/ccstatusline.js
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Configurable, powerful status line formatter for Claude Code";
+    homepage = "https://github.com/sirmalloc/ccstatusline";
+    changelog = "https://github.com/sirmalloc/ccstatusline/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    mainProgram = "ccstatusline";
+  };
+})

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,5 +3,6 @@
   # anytype = pkgs.callPackage ./anytype {};
   yuckls = pkgs.callPackage ./yuckls {};
   ccusage = pkgs.callPackage ./ccusage {};
+  ccstatusline = pkgs.callPackage ./ccstatusline {};
   pup = pkgs.callPackage ./pup {};
 }


### PR DESCRIPTION
## What

Adds [ccstatusline](https://github.com/sirmalloc/ccstatusline) as the status line for Claude Code — fully declarative: the binary **and** its configuration are managed by Nix, nothing is fetched at runtime.

### `pkgs/ccstatusline` — declarative package
ccstatusline ships a single self-contained bundle (`dist/ccstatusline.js`) with **zero runtime dependencies**, so the published npm tarball is fetched with `fetchurl` (pinned `v2.2.19` + SRI hash) and wrapped with `node`. No build step, no dependency-hash machinery, no runtime network access. Registered in `pkgs/default.nix` (`self.packages.${system}.ccstatusline`).

### `programs.ccstatusline` — new home-manager module
`modules/features/ccstatusline.nix` exposes a `programs.ccstatusline` module:
- `enable` — install the package + manage config
- `package` — defaults to the packaged ccstatusline
- `settings` — freeform JSON written verbatim to `~/.config/ccstatusline/settings.json` via `pkgs.formats.json`

The default `settings` reproduces ccstatusline's built-in v3 config (`model | context-length | git-branch | git-changes`) and can be overridden, e.g.:

```nix
programs.ccstatusline.settings.lines = [ [ /* widgets */ ] [] [] ];
```

Because the file is a read-only store symlink, the interactive TUI can't persist changes — the layout lives in this option instead (the module doc string notes this).

### `claude.nix`
- Enables `programs.ccstatusline`
- Points Claude Code's `statusLine.command` at `lib.getExe config.programs.ccstatusline.package`
- `combined.claude` imports the new module so it's available wherever claude is enabled

## Drive-by fix

`programs.claude-code` previously declared **two** `settings = { … }` attribute sets (permissions/hooks + enabledPlugins). Duplicate attribute keys in a single Nix attrset are an evaluation error, so they're consolidated into one. No behavioural change beyond making the module evaluate.

## Verification

- No `nix`/formatter in this environment, so the Nix was verified by inspection — please run `nix flake check` / `home-manager switch` before merging.
- Confirmed the **package** works by extracting the pinned tarball and running `node dist/ccstatusline.js` against a sample Claude Code payload (renders a status line, exits 0, zero deps).
- Confirmed the **default config** byte-for-byte matches ccstatusline's own generated `settings.json`, renders correctly, and is **not** rewritten on run (so the read-only store symlink won't be fought by the tool).

https://claude.ai/code/session_01QTbPSefaSQxkmkRT8D2JJE